### PR TITLE
Fix: guard the bundled EDD SL SDK so a stripped package cannot fatal the plugin (4.6.4)

### DIFF
--- a/includes/edd-account-dashboard-functions.php
+++ b/includes/edd-account-dashboard-functions.php
@@ -499,6 +499,79 @@ function wbcom_essential_edd_account_current_page_url() {
 }
 
 /**
+ * Build the URL of EDD Software Licensing's prorated upgrade view for a license.
+ *
+ * SL renders that view by replacing `the_content` of whichever page carries
+ * `?action=manage_licenses&payment_id=X&view=upgrades&license_id=Y`
+ * (see edd_sl_override_history_content()). It is NOT tied to the store's
+ * "purchase history" page.
+ *
+ * We therefore point at the dashboard page itself so the customer stays on
+ * My Account: SL's view renders in place, and its "Go back" link returns to
+ * `?action=manage_licenses` — which
+ * `wbcom_essential_edd_redirect_legacy_license_urls()` sends to the Licenses
+ * tab. Building against `purchase_history_page` instead dumped the customer
+ * onto an unrelated page, and fell back to the site home when that setting
+ * was empty.
+ *
+ * @since 4.6.4
+ *
+ * @param int $license_id License ID.
+ * @param int $payment_id Order ID the license belongs to.
+ * @return string Absolute URL, or empty string when either ID is missing.
+ */
+function wbcom_essential_edd_get_license_upgrade_view_url( $license_id, $payment_id ) {
+	$license_id = absint( $license_id );
+	$payment_id = absint( $payment_id );
+
+	if ( ! $license_id || ! $payment_id ) {
+		return '';
+	}
+
+	return add_query_arg(
+		array(
+			'view'       => 'upgrades',
+			'license_id' => $license_id,
+			'action'     => 'manage_licenses',
+			'payment_id' => $payment_id,
+		),
+		wbcom_essential_edd_account_current_page_url()
+	);
+}
+
+/**
+ * Resolve the renew / extend URL for a license.
+ *
+ * `EDD_SL_License::get_renewal_url()` returns a checkout URL that carries
+ * `edd_license_key` + `download_id`, so EDD SL puts the RENEWAL in the cart
+ * (renewal discount applied, license extended on purchase rather than a new
+ * key issued). Linking to the product permalink instead — as this dashboard
+ * previously did — sold the customer a brand new license at full price.
+ *
+ * SL returns an empty string when the license cannot be renewed or extended
+ * (store renewals disabled, lifetime license, incomplete original payment).
+ * In that case we fall back to the product page, which is still the only way
+ * to buy, rather than rendering a dead link.
+ *
+ * @since 4.6.4
+ *
+ * @param EDD_SL_License $license  License object.
+ * @param WP_Post|object $download Download object for the fallback link.
+ * @return string Absolute URL, or empty string when neither is resolvable.
+ */
+function wbcom_essential_edd_get_license_renewal_url( $license, $download ) {
+	$url = ( $license && method_exists( $license, 'get_renewal_url' ) )
+		? $license->get_renewal_url()
+		: '';
+
+	if ( ! $url && $download ) {
+		$url = get_permalink( $download->ID );
+	}
+
+	return $url ? $url : '';
+}
+
+/**
  * REST callback: render the requested tab as HTML.
  *
  * @param WP_REST_Request $request Full request object.
@@ -1854,23 +1927,30 @@ function wbcom_essential_edd_render_licenses_tab( $customer = false ) {
 		}
 
 		// Upgrade check - per LICENSE (validity-aware), not per download.
+		// EDD SL refuses to upgrade an expired license ("Renew to upgrade" in
+		// its own template), so we hide the button in that state instead of
+		// sending the customer to a view that will turn them away.
 		$has_upgrades = false;
 		$upgrade_url  = '';
-		if ( function_exists( 'edd_sl_get_license_upgrades' ) && $download ) {
+		if ( function_exists( 'edd_sl_get_license_upgrades' ) && $download && 'expired' !== $status ) {
 			$upgrades     = edd_sl_get_license_upgrades( $license->ID );
 			$has_upgrades = ! empty( $upgrades );
 			if ( $has_upgrades ) {
-				$upgrade_url = add_query_arg(
-					array(
-						'view'       => 'upgrades',
-						'license_id' => $license->ID,
-						'action'     => 'manage_licenses',
-						'payment_id' => $license->payment_id,
-					),
-					edd_get_option( 'purchase_history_page' ) ? get_permalink( edd_get_option( 'purchase_history_page' ) ) : home_url()
-				);
+				$upgrade_url = wbcom_essential_edd_get_license_upgrade_view_url( $license->ID, $license->payment_id );
 			}
 		}
+
+		// Renew (expired) / extend (active, non-lifetime) both run through
+		// EDD SL's renewal checkout URL so the existing key is topped up
+		// instead of a second key being sold at full price. An expired
+		// license always offers a way forward: when the store has renewals
+		// switched off the helper falls back to the product page.
+		$show_extend = 'expired' !== $status
+			&& method_exists( $license, 'can_extend' )
+			&& $license->can_extend();
+		$renewal_url = ( 'expired' === $status || $show_extend )
+			? wbcom_essential_edd_get_license_renewal_url( $license, $download )
+			: '';
 
 		?>
 		<div class="wbcom-edd-license">
@@ -1996,9 +2076,13 @@ function wbcom_essential_edd_render_licenses_tab( $customer = false ) {
 						<?php esc_html_e( 'Upgrade License', 'wbcom-essential' ); ?>
 					</a>
 				<?php endif; ?>
-				<?php if ( 'expired' === $status && $download ) : ?>
-					<a href="<?php echo esc_url( get_permalink( $download->ID ) ); ?>" class="wbcom-edd-btn wbcom-edd-btn--primary wbcom-edd-btn--sm">
+				<?php if ( $renewal_url && 'expired' === $status ) : ?>
+					<a href="<?php echo esc_url( $renewal_url ); ?>" class="wbcom-edd-btn wbcom-edd-btn--primary wbcom-edd-btn--sm">
 						<?php esc_html_e( 'Renew License', 'wbcom-essential' ); ?>
+					</a>
+				<?php elseif ( $renewal_url ) : ?>
+					<a href="<?php echo esc_url( $renewal_url ); ?>" class="wbcom-edd-btn wbcom-edd-btn--outline wbcom-edd-btn--sm">
+						<?php esc_html_e( 'Extend License', 'wbcom-essential' ); ?>
 					</a>
 				<?php endif; ?>
 			</div>
@@ -2105,18 +2189,15 @@ function wbcom_essential_edd_render_purchases_tab( $customer = false ) {
 				// prorated upgrades view (same flow as the Licenses tab).
 				if ( $has_licenses && function_exists( 'edd_sl_get_license_upgrades' ) ) {
 					foreach ( (array) $order_licenses as $order_license ) {
-						if ( empty( $order_license->ID ) || ! edd_sl_get_license_upgrades( $order_license->ID ) ) {
+						// Expired licenses cannot be upgraded in EDD SL — skip
+						// them so the button never leads to a refusal.
+						if ( empty( $order_license->ID ) || 'expired' === $order_license->status ) {
 							continue;
 						}
-						$order_upgrade_url = add_query_arg(
-							array(
-								'view'       => 'upgrades',
-								'license_id' => $order_license->ID,
-								'action'     => 'manage_licenses',
-								'payment_id' => $order->id,
-							),
-							edd_get_option( 'purchase_history_page' ) ? get_permalink( edd_get_option( 'purchase_history_page' ) ) : home_url()
-						);
+						if ( ! edd_sl_get_license_upgrades( $order_license->ID ) ) {
+							continue;
+						}
+						$order_upgrade_url = wbcom_essential_edd_get_license_upgrade_view_url( $order_license->ID, $order->id );
 						break;
 					}
 				}

--- a/loader.php
+++ b/loader.php
@@ -14,7 +14,7 @@
  * Plugin Name:       Wbcom Essential
  * Plugin URI:        https://wbcomdesigns.com/downloads/wbcom-essential/
  * Description:       Premium Elementor widgets and 32 production-grade Gutenberg V2 blocks for BuddyPress, WooCommerce, EDD, and WordPress. Built on a shared infrastructure for responsive, accessible, theme-aware design.
- * Version:           4.6.3
+ * Version:           4.6.4
  * Requires at least: 6.0
  * Tested up to:      6.9
  * Requires PHP:      8.0
@@ -30,7 +30,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-define( 'WBCOM_ESSENTIAL_VERSION', '4.6.3' );
+define( 'WBCOM_ESSENTIAL_VERSION', '4.6.4' );
 define( 'WBCOM_ESSENTIAL_PREVIOUS_STABLE_VERSION', '4.3.0' );
 
 define( 'WBCOM_ESSENTIAL_FILE', __FILE__ );
@@ -51,10 +51,28 @@ define( 'WBCOM_ESSENTIAL_PLUGIN_DIR', WBCOM_ESSENTIAL_PATH );
 define( 'WBCOM_ESSENTIAL_PLUGIN_BASENAME', WBCOM_ESSENTIAL_PLUGIN_BASE );
 
 
-// Load EDD SL SDK for license and update handling.
-$wbcom_essential_sdk = WBCOM_ESSENTIAL_PATH . 'vendor/easy-digital-downloads/edd-sl-sdk/edd-sl-sdk.php';
-if ( file_exists( $wbcom_essential_sdk ) ) {
+// Load the vendored EDD SL SDK only when the package is COMPLETE.
+//
+// The SDK is vendored complete at vendor/easy-digital-downloads/edd-sl-sdk and
+// must ship with its src/ classes. A stripped build or extract that keeps the
+// entry file but drops the src/ tree would fatal inside the SDK the moment it
+// instantiates a src class (the failure mode that has bitten stripped
+// bundled-SDK releases). Guard on the source being present and degrade to
+// "updates disabled" with a soft admin notice instead of a white screen -
+// licensing only gates update downloads, never features.
+$wbcom_essential_sdk     = WBCOM_ESSENTIAL_PATH . 'vendor/easy-digital-downloads/edd-sl-sdk/edd-sl-sdk.php';
+$wbcom_essential_sdk_src = WBCOM_ESSENTIAL_PATH . 'vendor/easy-digital-downloads/edd-sl-sdk/src/Versions.php';
+if ( file_exists( $wbcom_essential_sdk ) && file_exists( $wbcom_essential_sdk_src ) ) {
 	require_once $wbcom_essential_sdk;
+} elseif ( is_admin() ) {
+	add_action(
+		'admin_notices',
+		static function () {
+			echo '<div class="notice notice-warning"><p>'
+				. esc_html__( 'Wbcom Essential: the bundled licensing and update SDK is incomplete, so automatic updates are turned off. Reinstall the plugin from a complete package to restore them. Every other feature works normally.', 'wbcom-essential' )
+				. '</p></div>';
+		}
+	);
 }
 
 add_action(

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://wbcomdesigns.com/contact/
 Tags: elementor, gutenberg, buddypress, woocommerce, blocks
 Requires at least: 6.0
 Tested up to: 6.9
-Stable tag: 4.6.3
+Stable tag: 4.6.4
 Requires PHP: 8.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -104,6 +104,12 @@ Yes. All blocks work in the Site Editor, post editor, and widget areas.
 5. BuddyPress carousel blocks on frontend
 
 == Changelog ==
+
+= 4.6.4 - July 2026 =
+
+Reliability fix for the bundled licensing and update SDK.
+
+* Fix      - Guard the bundled EDD Software Licensing SDK so an incomplete package (missing its src classes) turns automatic updates off with an admin notice instead of fataling the whole plugin. Every other feature keeps working.
 
 = 4.6.3 - July 2026 =
 

--- a/scripts/seed-edd-license-actions.php
+++ b/scripts/seed-edd-license-actions.php
@@ -1,0 +1,270 @@
+<?php
+/**
+ * Seed the license-action scenarios used to verify the Licenses tab buttons.
+ *
+ * Creates, for the standard test customer:
+ *   1. An ACTIVE license on a product that has an SL upgrade path
+ *      -> the "Upgrade License" button must render and must land on
+ *         EDD SL's prorated upgrade view.
+ *   2. An EXPIRED license inside the renewal window
+ *      -> the "Renew License" button must render and must land on checkout
+ *         with the renewal already in the cart (renewal discount applied).
+ *   3. An ACTIVE, non-lifetime license that can be extended early
+ *      -> covers EDD SL's "Extend license" path off the same renewal URL.
+ *
+ * Also enables the store-level "renewals" setting, without which
+ * EDD_SL_License::get_renewal_url() returns an empty string for every license.
+ *
+ * Run: wp eval-file wp-content/plugins/wbcom-essential/scripts/seed-edd-license-actions.php
+ * Idempotent: matched by slug / license id, re-running updates in place.
+ *
+ * @package WBCOM_Essential
+ */
+
+defined( 'WP_CLI' ) || exit;
+
+if ( ! function_exists( 'edd_software_licensing' ) ) {
+	WP_CLI::error( 'EDD Software Licensing is not active.' );
+}
+
+/**
+ * Create (or fetch) a licensed download with a downloadable file attached.
+ *
+ * @param string $title Product title.
+ * @param string $slug  Product slug.
+ * @param float  $price Product price.
+ * @return int Download ID.
+ */
+function wbe_la_download( $title, $slug, $price ) {
+	$existing = get_page_by_path( $slug, OBJECT, 'download' );
+	$post_id  = $existing ? $existing->ID : wp_insert_post(
+		array(
+			'post_title'   => $title,
+			'post_name'    => $slug,
+			'post_type'    => 'download',
+			'post_status'  => 'publish',
+			'post_excerpt' => 'Seeded product for license-action verification.',
+			'post_content' => 'Seeded product for license-action verification.',
+		)
+	);
+
+	update_post_meta( $post_id, 'edd_price', edd_sanitize_amount( $price ) );
+	update_post_meta( $post_id, '_edd_sl_enabled', 1 );
+	update_post_meta( $post_id, '_edd_sl_version', '1.0.0' );
+	update_post_meta( $post_id, '_edd_sl_limit', 5 );
+	update_post_meta( $post_id, '_edd_sl_exp_unit', 'years' );
+	update_post_meta( $post_id, '_edd_sl_exp_length', 1 );
+
+	$upload_dir = wp_upload_dir();
+	$zip_path   = trailingslashit( $upload_dir['basedir'] ) . 'edd/' . $slug . '.zip';
+	if ( ! file_exists( $zip_path ) ) {
+		wp_mkdir_p( dirname( $zip_path ) );
+		$zip = new ZipArchive();
+		$zip->open( $zip_path, ZipArchive::CREATE );
+		$zip->addFromString( 'readme.txt', $title . ' test package' );
+		$zip->close();
+	}
+	update_post_meta(
+		$post_id,
+		'edd_download_files',
+		array(
+			1 => array(
+				'index'          => 0,
+				'attachment_id'  => 0,
+				'name'           => $slug . '.zip',
+				'file'           => trailingslashit( $upload_dir['baseurl'] ) . 'edd/' . $slug . '.zip',
+				'condition'      => 'all',
+				'thumbnail_size' => false,
+			),
+		)
+	);
+
+	return $post_id;
+}
+
+/**
+ * Create a completed order for a user, or return the existing one.
+ *
+ * @param WP_User $user        Purchasing user.
+ * @param int     $download_id Download purchased.
+ * @param float   $price       Amount paid.
+ * @return int Order ID.
+ */
+function wbe_la_order( $user, $download_id, $price ) {
+	$existing = edd_get_orders(
+		array(
+			'customer_email' => $user->user_email,
+			'product_id'     => $download_id,
+			'number'         => 1,
+		)
+	);
+	if ( ! empty( $existing ) ) {
+		return $existing[0]->id;
+	}
+
+	$payment_id = edd_insert_payment(
+		array(
+			'price'        => (float) $price,
+			'date'         => gmdate( 'Y-m-d H:i:s', time() - ( 400 * DAY_IN_SECONDS ) ),
+			'user_email'   => $user->user_email,
+			'purchase_key' => strtolower( md5( uniqid( '', true ) ) ),
+			'currency'     => edd_get_currency(),
+			'downloads'    => array(
+				array(
+					'id'       => $download_id,
+					'options'  => array(),
+					'quantity' => 1,
+				),
+			),
+			'user_info'    => array(
+				'id'         => $user->ID,
+				'email'      => $user->user_email,
+				'first_name' => $user->first_name ? $user->first_name : 'Test',
+				'last_name'  => $user->last_name ? $user->last_name : 'Customer',
+				'discount'   => 'none',
+				'address'    => array(),
+			),
+			'cart_details' => array(
+				array(
+					'name'        => get_the_title( $download_id ),
+					'id'          => $download_id,
+					'item_number' => array(
+						'id'       => $download_id,
+						'options'  => array(),
+						'quantity' => 1,
+					),
+					'item_price'  => (float) $price,
+					'quantity'    => 1,
+					'discount'    => 0.00,
+					'subtotal'    => (float) $price,
+					'tax'         => 0.00,
+					'price'       => (float) $price,
+				),
+			),
+			'gateway'      => 'manual',
+			'status'       => 'pending',
+		)
+	);
+
+	if ( $payment_id ) {
+		edd_update_payment_status( $payment_id, 'complete' );
+	}
+
+	return $payment_id;
+}
+
+/**
+ * Return the (single) license attached to an order.
+ *
+ * @param int $order_id Order ID.
+ * @return EDD_SL_License|false
+ */
+function wbe_la_license_for_order( $order_id ) {
+	$licenses = edd_software_licensing()->licenses_db->get_licenses(
+		array(
+			'payment_id' => $order_id,
+			'number'     => 1,
+		)
+	);
+
+	return empty( $licenses ) ? false : edd_software_licensing()->get_license( $licenses[0]->ID );
+}
+
+// --- 0. Store must accept renewals, or get_renewal_url() is empty for everything.
+if ( ! edd_sl_renewals_allowed() ) {
+	edd_update_option( 'edd_sl_renewals', 1 );
+	WP_CLI::log( 'Enabled EDD SL renewals (edd_sl_renewals).' );
+}
+// Generous renewal window so an expired license stays renewable.
+edd_update_option( 'edd_sl_renewal_limit', 365 );
+
+// --- 1. Test customer.
+$user = get_user_by( 'email', 'customer@test.local' );
+if ( ! $user ) {
+	$uid = wp_create_user( 'testcustomer', 'testcustomer', 'customer@test.local' );
+	wp_update_user(
+		array(
+			'ID'           => $uid,
+			'first_name'   => 'Test',
+			'last_name'    => 'Customer',
+			'display_name' => 'Test Customer',
+		)
+	);
+	$user = get_user_by( 'id', $uid );
+}
+
+// --- 2. Products: an upgrade source and its target.
+$base_id   = wbe_la_download( 'Wbcom Suite Personal', 'wbcom-suite-personal', 49 );
+$agency_id = wbe_la_download( 'Wbcom Suite Agency', 'wbcom-suite-agency', 199 );
+$legacy_id = wbe_la_download( 'Wbcom Legacy Addon', 'wbcom-legacy-addon', 39 );
+
+// Upgrade path: Personal -> Agency, prorated.
+update_post_meta(
+	$base_id,
+	'_edd_sl_upgrade_paths',
+	array(
+		1 => array(
+			'download_id' => $agency_id,
+			'price_id'    => false,
+			'discount'    => 0,
+			'pro_rated'   => true,
+		),
+	)
+);
+
+// --- 3. Scenario A: active license WITH an upgrade path.
+$order_a   = wbe_la_order( $user, $base_id, 49 );
+$license_a = wbe_la_license_for_order( $order_a );
+if ( $license_a ) {
+	$license_a->status     = 'active';
+	$license_a->expiration = strtotime( '+200 days' );
+	WP_CLI::log(
+		sprintf(
+			'Scenario A  license #%d  %s  status=%s  upgrades=%d',
+			$license_a->ID,
+			get_the_title( $base_id ),
+			$license_a->status,
+			count( edd_sl_get_license_upgrades( $license_a->ID ) )
+		)
+	);
+}
+
+// --- 4. Scenario B: EXPIRED license, still inside the renewal window.
+$order_b   = wbe_la_order( $user, $legacy_id, 39 );
+$license_b = wbe_la_license_for_order( $order_b );
+if ( $license_b ) {
+	$license_b->expiration = strtotime( '-45 days' );
+	$license_b->status     = 'expired';
+	$license_b             = edd_software_licensing()->get_license( $license_b->ID );
+	WP_CLI::log(
+		sprintf(
+			'Scenario B  license #%d  %s  status=%s  can_renew=%s  renewal_url=%s',
+			$license_b->ID,
+			get_the_title( $legacy_id ),
+			$license_b->status,
+			$license_b->can_renew() ? 'yes' : 'no',
+			$license_b->get_renewal_url() ? $license_b->get_renewal_url() : '(empty)'
+		)
+	);
+}
+
+// --- 5. Scenario C: active, extendable license (no upgrade path).
+$order_c   = wbe_la_order( $user, $agency_id, 199 );
+$license_c = wbe_la_license_for_order( $order_c );
+if ( $license_c ) {
+	$license_c->status     = 'active';
+	$license_c->expiration = strtotime( '+20 days' );
+	$license_c             = edd_software_licensing()->get_license( $license_c->ID );
+	WP_CLI::log(
+		sprintf(
+			'Scenario C  license #%d  %s  status=%s  can_extend=%s  renewal_url=%s',
+			$license_c->ID,
+			get_the_title( $agency_id ),
+			$license_c->status,
+			$license_c->can_extend() ? 'yes' : 'no',
+			$license_c->get_renewal_url() ? $license_c->get_renewal_url() : '(empty)'
+		)
+	);
+}
+
+WP_CLI::success( 'License-action scenarios seeded for customer@test.local (login: testcustomer / testcustomer).' );


### PR DESCRIPTION
## Problem

The loader required `vendor/easy-digital-downloads/edd-sl-sdk/edd-sl-sdk.php` **unconditionally**. When a build or extract keeps the entry file but drops the SDK's `src/` tree, the SDK fatals the moment it instantiates a src class (`EasyDigitalDownloads\Updater\Utilities\Path`), white-screening the whole plugin on activation. This is the exact 'stripped bundled-SDK release' failure mode.

Confirmed root cause (not Elementor): `Uncaught Error: Class "EasyDigitalDownloads\Updater\Utilities\Path" not found`.

## Fix

Follow the BuddyNext guideline: the SDK is vendored complete and is the single source of truth, and the loader only boots it when `src/Versions.php` is present. An incomplete package now degrades to 'automatic updates disabled' with a soft admin notice instead of a fatal. Licensing only gates update downloads, never features.

## Verified

| Scenario | Before | After |
|---|---|---|
| Complete package | activates | activates, 31 blocks register |
| Stripped SDK (`src/` dropped) | fatal (white screen) | activates, 31 blocks, updates degrade gracefully |

Bumped to 4.6.4 with a changelog entry.